### PR TITLE
Improve DWG conversion layout handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+target/
+*.log
+*.iml
+.idea/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ target/
 *.iml
 .idea/
 .DS_Store
+*.xls*
+*.doc*
+*.pdf
+*.dwg
+*.png
+*.jpg

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ mvn -DskipTests package
 
 Detta skapar både en körbar JAR (`target/asposetopdf-1.0.0-jar-with-dependencies.jar`) och förbereder underlaget för jpackage.
 
+> **Tips:** Aspose publicerar sina beroenden i det öppna Maven-arkivet som beskrivs på <https://releases.aspose.com/total/java/>. `pom.xml` är redan konfigurerad att använda repositoryt `https://releases.aspose.com/java/repo/`, så du behöver inga licensuppgifter för att hämta biblioteken.
+
 ## Köra från JAR
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
 # AsposeToPDF
+
+Ett enkelt kommandoradsverktyg för att konvertera olika dokumentformat till PDF med hjälp av Aspose Total for Java.
+
+## Bygga
+
+```bash
+mvn -DskipTests package
+```
+
+Detta skapar både en körbar JAR (`target/asposetopdf-1.0.0-jar-with-dependencies.jar`) och förbereder underlaget för jpackage.
+
+## Köra från JAR
+
+```bash
+java -jar target/asposetopdf-1.0.0-jar-with-dependencies.jar <indatafil> [utdatafil]
+```
+
+Om `utdatafil` inte anges skapas en PDF med samma namn som indatafilen men med ändelsen `.pdf`.
+
+## Paketera med jpackage
+
+För att skapa en plattformsanpassad app-image (som kan köras utan installerad JRE) används jpackage via Maven:
+
+```bash
+mvn -DskipTests package jpackage:jpackage
+```
+
+Detta producerar en app-image under `target/installer/AsposeToPdf`. Kopiera katalogen till målmaskinen och kör startskriptet inuti.
+
+> **Obs!** jpackage kräver ett JDK (17 eller senare) med jpackage-kommandot installerat på byggmaskinen.
+
+## Stödda format
+
+* PDF
+* JPG/JPEG
+* PNG
+* TIFF/TIF
+* DOCX
+* XLSX
+* PPTX
+* EML
+* MSG
+* Visio (VSDX)
+* DWG (Model-layouten exporteras som standard och eventuella papperslayouter identifieras automatiskt)
+
+Filtypen bestäms i första hand via filens magiska bytes. Om typen inte kan avgöras på detta sätt används filändelsen som reserv.
+
+## Aspose-licens
+
+Om du har en Aspose Total-licens kan den aktiveras genom att sätta miljövariabeln `ASPOSE_LICENSE_PATH` till sökvägen av licensfilen innan programmet startas.

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
 
     <repositories>
         <repository>
-            <id>AsposeJavaAPI</id>
-            <name>Aspose Java API</name>
-            <url>https://repository.aspose.com/repo/</url>
+            <id>AsposeReleases</id>
+            <name>Aspose Release Repository</name>
+            <url>https://releases.aspose.com/java/repo/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.example</groupId>
@@ -10,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>25</maven.compiler.release>
         <main.class>com.example.asposetopdf.App</main.class>
     </properties>
 
@@ -92,6 +93,11 @@
                         <javaOption>-Xmx1024m</javaOption>
                     </javaOptions>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.2.0</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,98 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>asposetopdf</artifactId>
+    <version>1.0.0</version>
+    <name>AsposeToPDF</name>
+    <description>Command line converter to PDF using Aspose.Total for Java.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+        <main.class>com.example.asposetopdf.App</main.class>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.aspose</groupId>
+            <artifactId>aspose-total</artifactId>
+            <version>25.8</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>AsposeJavaAPI</id>
+            <name>Aspose Java API</name>
+            <url>https://repository.aspose.com/repo/</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>${main.class}</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>${main.class}</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.panteleyev</groupId>
+                <artifactId>jpackage-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <configuration>
+                    <input>${project.build.directory}</input>
+                    <destination>${project.build.directory}/installer</destination>
+                    <type>app-image</type>
+                    <name>AsposeToPdf</name>
+                    <mainClass>${main.class}</mainClass>
+                    <mainJar>${project.build.finalName}-jar-with-dependencies.jar</mainJar>
+                    <javaOptions>
+                        <javaOption>-Xmx1024m</javaOption>
+                    </javaOptions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/asposetopdf/App.java
+++ b/src/main/java/com/example/asposetopdf/App.java
@@ -1,0 +1,66 @@
+package com.example.asposetopdf;
+
+import com.example.asposetopdf.converters.ConversionService;
+import com.example.asposetopdf.detect.FileType;
+import com.example.asposetopdf.detect.FileTypeDetector;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Entry point for the Aspose to PDF command line converter.
+ */
+public final class App {
+
+    private App() {
+    }
+
+    public static void main(String[] args) {
+        if (args.length == 0 || args.length > 2) {
+            printUsage();
+            System.exit(1);
+        }
+
+        Path inputPath = Paths.get(args[0]);
+        if (!Files.exists(inputPath)) {
+            System.err.printf("Input file '%s' does not exist.%n", inputPath);
+            System.exit(2);
+        }
+
+        Path outputPath;
+        if (args.length == 2) {
+            outputPath = Paths.get(args[1]);
+        } else {
+            String fileName = inputPath.getFileName().toString();
+            int dotIndex = fileName.lastIndexOf('.');
+            if (dotIndex > 0) {
+                fileName = fileName.substring(0, dotIndex);
+            }
+            Path parent = inputPath.toAbsolutePath().getParent();
+            outputPath = parent == null ? Paths.get(fileName + ".pdf") : parent.resolve(fileName + ".pdf");
+        }
+
+        try {
+            LicenseLoader.applyLicenses();
+            FileType type = FileTypeDetector.detect(inputPath);
+            new ConversionService().convert(type, inputPath, outputPath);
+            System.out.printf("Converted %s to %s%n", inputPath, outputPath);
+        } catch (UnsupportedOperationException ex) {
+            System.err.println(ex.getMessage());
+            System.exit(3);
+        } catch (IOException ex) {
+            System.err.printf("Failed to detect file type: %s%n", ex.getMessage());
+            System.exit(4);
+        } catch (Exception ex) {
+            System.err.printf("Conversion failed: %s%n", ex.getMessage());
+            ex.printStackTrace(System.err);
+            System.exit(5);
+        }
+    }
+
+    private static void printUsage() {
+        System.err.println("Usage: AsposeToPDF <input-file> [output-file]");
+    }
+}

--- a/src/main/java/com/example/asposetopdf/LicenseLoader.java
+++ b/src/main/java/com/example/asposetopdf/LicenseLoader.java
@@ -1,0 +1,47 @@
+package com.example.asposetopdf;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Applies Aspose licenses when available.
+ */
+public final class LicenseLoader {
+    private static final String LICENSE_ENV = "ASPOSE_LICENSE_PATH";
+
+    private LicenseLoader() {
+    }
+
+    public static void applyLicenses() {
+        String licensePath = System.getenv(LICENSE_ENV);
+        if (licensePath == null || licensePath.isBlank()) {
+            return;
+        }
+        Path path = Path.of(licensePath);
+        if (!Files.exists(path)) {
+            System.err.printf("Aspose license file not found at %s%n", path);
+            return;
+        }
+
+        setLicense(() -> new com.aspose.pdf.License().setLicense(path.toString()));
+        setLicense(() -> new com.aspose.words.License().setLicense(path.toString()));
+        setLicense(() -> new com.aspose.cells.License().setLicense(path.toString()));
+        setLicense(() -> new com.aspose.slides.License().setLicense(path.toString()));
+        setLicense(() -> new com.aspose.diagram.License().setLicense(path.toString()));
+        setLicense(() -> new com.aspose.email.License().setLicense(path.toString()));
+        setLicense(() -> new com.aspose.imaging.License().setLicense(path.toString()));
+    }
+
+    @FunctionalInterface
+    private interface LicenseApplier {
+        void apply() throws Exception;
+    }
+
+    private static void setLicense(LicenseApplier applier) {
+        try {
+            applier.apply();
+        } catch (Exception ex) {
+            System.err.printf("Failed to apply license: %s%n", ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/BaseConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/BaseConverter.java
@@ -1,0 +1,18 @@
+package com.example.asposetopdf.converters;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Shared utilities for converters.
+ */
+abstract class BaseConverter implements FormatConverter {
+
+    protected void ensureParentDirectory(Path output) throws IOException {
+        Path parent = output.toAbsolutePath().getParent();
+        if (parent != null && !Files.exists(parent)) {
+            Files.createDirectories(parent);
+        }
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/ConversionService.java
+++ b/src/main/java/com/example/asposetopdf/converters/ConversionService.java
@@ -1,0 +1,40 @@
+package com.example.asposetopdf.converters;
+
+import com.example.asposetopdf.detect.FileType;
+
+import java.nio.file.Path;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Dispatches conversion to the proper format specific converter.
+ */
+public class ConversionService {
+    private final Map<FileType, FormatConverter> converters = new EnumMap<>(FileType.class);
+
+    public ConversionService() {
+        register(new PdfConverter());
+        register(new JpegConverter());
+        register(new PngConverter());
+        register(new TiffConverter());
+        register(new DocxConverter());
+        register(new EmlConverter());
+        register(new MsgConverter());
+        register(new XlsxConverter());
+        register(new VisioConverter());
+        register(new PptxConverter());
+        register(new DwgConverter());
+    }
+
+    private void register(FormatConverter converter) {
+        converters.put(converter.getFileType(), converter);
+    }
+
+    public void convert(FileType type, Path input, Path output) throws Exception {
+        FormatConverter converter = converters.get(type);
+        if (converter == null) {
+            throw new UnsupportedOperationException("No converter registered for type " + type);
+        }
+        converter.convert(input, output);
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/DocxConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/DocxConverter.java
@@ -1,7 +1,6 @@
 package com.example.asposetopdf.converters;
 
-import com.aspose.words.Document;
-import com.aspose.words.SaveFormat;
+import com.aspose.words.*;
 import com.example.asposetopdf.detect.FileType;
 
 import java.nio.file.Path;
@@ -19,6 +18,20 @@ public class DocxConverter extends BaseConverter {
     public void convert(Path input, Path output) throws Exception {
         ensureParentDirectory(output);
         Document document = new Document(input.toString());
-        document.save(output.toString(), SaveFormat.PDF);
+        PdfSaveOptions pdfOptions = new PdfSaveOptions();
+        pdfOptions.setExportDocumentStructure(true);
+        pdfOptions.setDisplayDocTitle(true);
+        pdfOptions.setExportLanguageToSpanTag(true);
+        pdfOptions.setExportParagraphGraphicsToArtifact(true);
+        pdfOptions.setPageMode(PdfPageMode.USE_OUTLINES);
+
+        OutlineOptions outline = pdfOptions.getOutlineOptions();
+        outline.setDefaultBookmarksOutlineLevel(1);
+        outline.setHeadingsOutlineLevels(3);
+        document.save(output.toString(), pdfOptions);
     }
 }
+
+
+
+

--- a/src/main/java/com/example/asposetopdf/converters/DocxConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/DocxConverter.java
@@ -1,0 +1,24 @@
+package com.example.asposetopdf.converters;
+
+import com.aspose.words.Document;
+import com.aspose.words.SaveFormat;
+import com.example.asposetopdf.detect.FileType;
+
+import java.nio.file.Path;
+
+/**
+ * Converter for DOCX files.
+ */
+public class DocxConverter extends BaseConverter {
+    @Override
+    public FileType getFileType() {
+        return FileType.DOCX;
+    }
+
+    @Override
+    public void convert(Path input, Path output) throws Exception {
+        ensureParentDirectory(output);
+        Document document = new Document(input.toString());
+        document.save(output.toString(), SaveFormat.PDF);
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/DwgConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/DwgConverter.java
@@ -1,0 +1,119 @@
+package com.example.asposetopdf.converters;
+
+import com.aspose.cad.Image;
+import com.aspose.cad.imageoptions.CadRasterizationOptions;
+import com.aspose.cad.imageoptions.PdfOptions;
+import com.example.asposetopdf.detect.FileType;
+
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Converter for DWG CAD drawings.
+ */
+public class DwgConverter extends BaseConverter {
+    @Override
+    public FileType getFileType() {
+        return FileType.DWG;
+    }
+
+    @Override
+    public void convert(Path input, Path output) throws Exception {
+        ensureParentDirectory(output);
+        try (Image image = Image.load(input.toString())) {
+            CadRasterizationOptions rasterization = new CadRasterizationOptions();
+            rasterization.setAutomaticLayoutsScaling(true);
+            rasterization.setNoScaling(false);
+
+            String[] layouts = determineLayouts(image);
+            if (layouts.length > 0) {
+                rasterization.setLayouts(layouts);
+            } else {
+                rasterization.setLayouts(new String[]{"Model"});
+            }
+
+            int width = image.getWidth();
+            int height = image.getHeight();
+            if (width > 0 && height > 0) {
+                rasterization.setPageWidth(width);
+                rasterization.setPageHeight(height);
+            }
+
+            PdfOptions pdfOptions = new PdfOptions();
+            pdfOptions.setVectorRasterizationOptions(rasterization);
+            image.save(output.toString(), pdfOptions);
+        }
+    }
+
+    private String[] determineLayouts(Image image) {
+        Set<String> names = new LinkedHashSet<>();
+        names.add("Model");
+        for (String name : extractLayoutsViaReflection(image)) {
+            if (name != null && !name.isBlank()) {
+                names.add(name);
+            }
+        }
+        return names.toArray(String[]::new);
+    }
+
+    private List<String> extractLayoutsViaReflection(Image image) {
+        List<String> layouts = new ArrayList<>();
+        try {
+            Method getLayouts = image.getClass().getMethod("getLayouts");
+            Object layoutsObject = getLayouts.invoke(image);
+            if (layoutsObject == null) {
+                return layouts;
+            }
+            if (layoutsObject instanceof String[] stringArray) {
+                for (String layout : stringArray) {
+                    layouts.add(layout);
+                }
+                return layouts;
+            }
+            if (layoutsObject instanceof Iterable<?> iterable) {
+                for (Object entry : iterable) {
+                    String name = extractLayoutName(entry);
+                    if (name != null) {
+                        layouts.add(name);
+                    }
+                }
+                return layouts;
+            }
+            Method toArray = layoutsObject.getClass().getMethod("toArray");
+            Object asArray = toArray.invoke(layoutsObject);
+            if (asArray instanceof Object[] objects) {
+                for (Object entry : objects) {
+                    String name = extractLayoutName(entry);
+                    if (name != null) {
+                        layouts.add(name);
+                    }
+                }
+            }
+        } catch (ReflectiveOperationException ignored) {
+            // If the API differs, fall back to default Model layout.
+        }
+        return layouts;
+    }
+
+    private String extractLayoutName(Object layoutObject) {
+        if (layoutObject == null) {
+            return null;
+        }
+        for (String methodName : new String[]{"getLayoutName", "getName", "getKey"}) {
+            try {
+                Method method = layoutObject.getClass().getMethod(methodName);
+                Object value = method.invoke(layoutObject);
+                if (value instanceof String name) {
+                    return name;
+                }
+            } catch (ReflectiveOperationException ignored) {
+                // Try the next accessor name.
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/EmlConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/EmlConverter.java
@@ -2,10 +2,8 @@ package com.example.asposetopdf.converters;
 
 import com.aspose.email.MailMessage;
 import com.aspose.email.SaveOptions;
-import com.aspose.words.Document;
-import com.aspose.words.LoadFormat;
-import com.aspose.words.LoadOptions;
-import com.aspose.words.SaveFormat;
+import com.aspose.html.converters.Converter;
+import com.aspose.html.saving.PdfSaveOptions;
 import com.example.asposetopdf.detect.FileType;
 
 import java.io.ByteArrayInputStream;
@@ -24,12 +22,13 @@ public class EmlConverter extends BaseConverter {
     @Override
     public void convert(Path input, Path output) throws Exception {
         ensureParentDirectory(output);
-        MailMessage message = MailMessage.load(input.toString());
-        try (ByteArrayOutputStream mhtmlStream = new ByteArrayOutputStream()) {
-            message.save(mhtmlStream, SaveOptions.getDefaultMhtml());
-            Document document = new Document(new ByteArrayInputStream(mhtmlStream.toByteArray()),
-                new LoadOptions(LoadFormat.MHTML));
-            document.save(output.toString(), SaveFormat.PDF);
+        try (MailMessage mailMessage = MailMessage.load(input.toString());
+             ByteArrayOutputStream mhtmlStream = new ByteArrayOutputStream()) {
+            mailMessage.save(mhtmlStream, SaveOptions.getDefaultMhtml());
+            byte[] mhtmlBytes = mhtmlStream.toByteArray();
+            try (ByteArrayInputStream mhtmlInput = new ByteArrayInputStream(mhtmlBytes)) {
+                Converter.convertMHTML(mhtmlInput, new PdfSaveOptions(), output.toString());
+            }
         }
     }
 }

--- a/src/main/java/com/example/asposetopdf/converters/EmlConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/EmlConverter.java
@@ -1,0 +1,35 @@
+package com.example.asposetopdf.converters;
+
+import com.aspose.email.MailMessage;
+import com.aspose.email.SaveOptions;
+import com.aspose.words.Document;
+import com.aspose.words.LoadFormat;
+import com.aspose.words.LoadOptions;
+import com.aspose.words.SaveFormat;
+import com.example.asposetopdf.detect.FileType;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Path;
+
+/**
+ * Converter for EML email messages.
+ */
+public class EmlConverter extends BaseConverter {
+    @Override
+    public FileType getFileType() {
+        return FileType.EML;
+    }
+
+    @Override
+    public void convert(Path input, Path output) throws Exception {
+        ensureParentDirectory(output);
+        MailMessage message = MailMessage.load(input.toString());
+        try (ByteArrayOutputStream mhtmlStream = new ByteArrayOutputStream()) {
+            message.save(mhtmlStream, SaveOptions.getDefaultMhtml());
+            Document document = new Document(new ByteArrayInputStream(mhtmlStream.toByteArray()),
+                new LoadOptions(LoadFormat.MHTML));
+            document.save(output.toString(), SaveFormat.PDF);
+        }
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/FormatConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/FormatConverter.java
@@ -1,0 +1,14 @@
+package com.example.asposetopdf.converters;
+
+import com.example.asposetopdf.detect.FileType;
+
+import java.nio.file.Path;
+
+/**
+ * Base interface for type specific converters.
+ */
+public interface FormatConverter {
+    FileType getFileType();
+
+    void convert(Path input, Path output) throws Exception;
+}

--- a/src/main/java/com/example/asposetopdf/converters/ImageConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/ImageConverter.java
@@ -1,0 +1,67 @@
+package com.example.asposetopdf.converters;
+
+import com.aspose.imaging.Image;
+import com.aspose.pdf.Document;
+import com.aspose.pdf.MarginInfo;
+import com.aspose.pdf.Page;
+import com.example.asposetopdf.detect.FileType;
+
+import java.nio.file.Path;
+
+/**
+ * Base converter for raster image types.
+ */
+public class ImageConverter extends BaseConverter {
+    private final FileType fileType;
+    private static final double POINTS_PER_INCH = 72.0;
+    private static final double FALLBACK_DPI = 96.0;
+
+    public ImageConverter(FileType fileType) {
+        this.fileType = fileType;
+    }
+
+    @Override
+    public FileType getFileType() {
+        return fileType;
+    }
+
+    @Override
+    public void convert(Path input, Path output) throws Exception {
+        ensureParentDirectory(output);
+        try (Image imageInfo = Image.load(input.toString())) {
+            Document document = new Document();
+            try {
+                MarginInfo margin = new MarginInfo(0, 0, 0, 0);
+                document.getPageInfo().setMargin(margin);
+
+                Page page = document.getPages().add();
+                page.getPageInfo().setMargin(margin);
+                setPageDimensions(page, imageInfo.getWidth(), imageInfo.getHeight(),
+                        imageInfo.getHorizontalResolution(), imageInfo.getVerticalResolution());
+
+                com.aspose.pdf.Image pdfImage = new com.aspose.pdf.Image();
+                pdfImage.setFile(input.toString());
+                pdfImage.setFixWidth(page.getPageInfo().getWidth());
+                pdfImage.setFixHeight(page.getPageInfo().getHeight());
+                pdfImage.setIsApplyResolution(true);
+                page.getParagraphs().add(pdfImage);
+
+                document.save(output.toString());
+            } finally {
+                document.close();
+            }
+        }
+    }
+
+    protected void setPageDimensions(Page page, int pixelWidth, int pixelHeight, double horizontalDpi, double verticalDpi) {
+        double widthPoints = toPoints(pixelWidth, horizontalDpi);
+        double heightPoints = toPoints(pixelHeight, verticalDpi);
+        page.getPageInfo().setWidth(widthPoints);
+        page.getPageInfo().setHeight(heightPoints);
+    }
+
+    private double toPoints(int pixels, double dpi) {
+        double effectiveDpi = dpi > 0 ? dpi : FALLBACK_DPI;
+        return pixels / effectiveDpi * POINTS_PER_INCH;
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/ImageConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/ImageConverter.java
@@ -7,7 +7,7 @@ import com.aspose.pdf.MarginInfo;
 import com.aspose.pdf.Matrix;
 import com.aspose.pdf.Page;
 import com.aspose.pdf.Rectangle;
-import com.aspose.pdf.XImage;
+import com.aspose.pdf.ImageFilterType;
 import com.aspose.pdf.XImageCollection;
 import com.aspose.pdf.operators.ConcatenateMatrix;
 import com.aspose.pdf.operators.Do;
@@ -15,6 +15,9 @@ import com.aspose.pdf.operators.GRestore;
 import com.aspose.pdf.operators.GSave;
 import com.example.asposetopdf.detect.FileType;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
@@ -82,23 +85,35 @@ public class ImageConverter extends BaseConverter {
     }
 
     protected void embedImage(Page page, Path input, double widthPoints, double heightPoints) {
-        com.aspose.pdf.Image pdfImage = new com.aspose.pdf.Image();
-        pdfImage.setFile(input.toString());
-        pdfImage.setFixWidth(widthPoints);
-        pdfImage.setFixHeight(heightPoints);
-        pdfImage.setIsApplyResolution(true);
-        page.getParagraphs().add(pdfImage);
+        try {
+            byte[] imageData = Files.readAllBytes(input);
+            embedImage(page, imageData, widthPoints, heightPoints, getDefaultImageFilter());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to embed image " + input, e);
+        }
     }
 
-    protected void embedNativeImage(Page page, Path input, double widthPoints, double heightPoints) {
-        XImageCollection images = page.getResources().getImages();
-        XImage xImage = images.add(input.toString());
+    protected void embedImage(Page page, byte[] imageData, double widthPoints, double heightPoints) {
+        embedImage(page, imageData, widthPoints, heightPoints, getDefaultImageFilter());
+    }
 
-        page.getContents().add(new GSave());
-        Matrix matrix = new Matrix(new double[]{widthPoints, 0, 0, heightPoints, 0, 0});
-        page.getContents().add(new ConcatenateMatrix(matrix));
-        page.getContents().add(new Do(xImage.getName()));
-        page.getContents().add(new GRestore());
+    protected void embedImage(Page page, byte[] imageData, double widthPoints, double heightPoints, int filterType) {
+        XImageCollection images = page.getResources().getImages();
+        try (ByteArrayInputStream imageStream = new ByteArrayInputStream(imageData)) {
+            String imageName = images.addWithImageFilterType(imageStream, filterType);
+
+            page.getContents().add(new GSave());
+            Matrix matrix = new Matrix(new double[]{widthPoints, 0, 0, heightPoints, 0, 0});
+            page.getContents().add(new ConcatenateMatrix(matrix));
+            page.getContents().add(new Do(imageName));
+            page.getContents().add(new GRestore());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to embed image with filter " + filterType, e);
+        }
+    }
+
+    protected int getDefaultImageFilter() {
+        return ImageFilterType.Flate;
     }
 
     private double toPoints(int pixels, double dpi) {

--- a/src/main/java/com/example/asposetopdf/converters/ImageConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/ImageConverter.java
@@ -1,6 +1,7 @@
 package com.example.asposetopdf.converters;
 
 import com.aspose.imaging.Image;
+import com.aspose.imaging.RasterImage;
 import com.aspose.pdf.Document;
 import com.aspose.pdf.MarginInfo;
 import com.aspose.pdf.Matrix;
@@ -37,6 +38,16 @@ public class ImageConverter extends BaseConverter {
     public void convert(Path input, Path output) throws Exception {
         ensureParentDirectory(output);
         try (Image imageInfo = Image.load(input.toString())) {
+            int pixelWidth = imageInfo.getWidth();
+            int pixelHeight = imageInfo.getHeight();
+            double horizontalDpi = FALLBACK_DPI;
+            double verticalDpi = FALLBACK_DPI;
+
+            if (imageInfo instanceof RasterImage raster) {
+                horizontalDpi = raster.getHorizontalResolution();
+                verticalDpi = raster.getVerticalResolution();
+            }
+
             Document document = new Document();
             try {
                 MarginInfo margin = new MarginInfo(0, 0, 0, 0);
@@ -44,11 +55,10 @@ public class ImageConverter extends BaseConverter {
 
                 Page page = document.getPages().add();
                 page.getPageInfo().setMargin(margin);
-                setPageDimensions(page, imageInfo.getWidth(), imageInfo.getHeight(),
-                        imageInfo.getHorizontalResolution(), imageInfo.getVerticalResolution());
+                setPageDimensions(page, pixelWidth, pixelHeight, horizontalDpi, verticalDpi);
 
-                double widthPoints = toPoints(imageInfo.getWidth(), imageInfo.getHorizontalResolution());
-                double heightPoints = toPoints(imageInfo.getHeight(), imageInfo.getVerticalResolution());
+                double widthPoints = toPoints(pixelWidth, horizontalDpi);
+                double heightPoints = toPoints(pixelHeight, verticalDpi);
                 embedImage(page, input, widthPoints, heightPoints);
 
                 document.save(output.toString());

--- a/src/main/java/com/example/asposetopdf/converters/ImageConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/ImageConverter.java
@@ -3,7 +3,15 @@ package com.example.asposetopdf.converters;
 import com.aspose.imaging.Image;
 import com.aspose.pdf.Document;
 import com.aspose.pdf.MarginInfo;
+import com.aspose.pdf.Matrix;
 import com.aspose.pdf.Page;
+import com.aspose.pdf.Rectangle;
+import com.aspose.pdf.XImage;
+import com.aspose.pdf.XImageCollection;
+import com.aspose.pdf.operators.ConcatenateMatrix;
+import com.aspose.pdf.operators.Do;
+import com.aspose.pdf.operators.GRestore;
+import com.aspose.pdf.operators.GSave;
 import com.example.asposetopdf.detect.FileType;
 
 import java.nio.file.Path;
@@ -39,12 +47,9 @@ public class ImageConverter extends BaseConverter {
                 setPageDimensions(page, imageInfo.getWidth(), imageInfo.getHeight(),
                         imageInfo.getHorizontalResolution(), imageInfo.getVerticalResolution());
 
-                com.aspose.pdf.Image pdfImage = new com.aspose.pdf.Image();
-                pdfImage.setFile(input.toString());
-                pdfImage.setFixWidth(page.getPageInfo().getWidth());
-                pdfImage.setFixHeight(page.getPageInfo().getHeight());
-                pdfImage.setIsApplyResolution(true);
-                page.getParagraphs().add(pdfImage);
+                double widthPoints = toPoints(imageInfo.getWidth(), imageInfo.getHorizontalResolution());
+                double heightPoints = toPoints(imageInfo.getHeight(), imageInfo.getVerticalResolution());
+                embedImage(page, input, widthPoints, heightPoints);
 
                 document.save(output.toString());
             } finally {
@@ -58,6 +63,32 @@ public class ImageConverter extends BaseConverter {
         double heightPoints = toPoints(pixelHeight, verticalDpi);
         page.getPageInfo().setWidth(widthPoints);
         page.getPageInfo().setHeight(heightPoints);
+        Rectangle crop = new Rectangle(0, 0, widthPoints, heightPoints);
+        page.setCropBox(crop);
+        page.setMediaBox(crop);
+        page.setTrimBox(crop);
+        page.setBleedBox(crop);
+        page.setArtBox(crop);
+    }
+
+    protected void embedImage(Page page, Path input, double widthPoints, double heightPoints) {
+        com.aspose.pdf.Image pdfImage = new com.aspose.pdf.Image();
+        pdfImage.setFile(input.toString());
+        pdfImage.setFixWidth(widthPoints);
+        pdfImage.setFixHeight(heightPoints);
+        pdfImage.setIsApplyResolution(true);
+        page.getParagraphs().add(pdfImage);
+    }
+
+    protected void embedNativeImage(Page page, Path input, double widthPoints, double heightPoints) {
+        XImageCollection images = page.getResources().getImages();
+        XImage xImage = images.add(input.toString());
+
+        page.getContents().add(new GSave());
+        Matrix matrix = new Matrix(new double[]{widthPoints, 0, 0, heightPoints, 0, 0});
+        page.getContents().add(new ConcatenateMatrix(matrix));
+        page.getContents().add(new Do(xImage.getName()));
+        page.getContents().add(new GRestore());
     }
 
     private double toPoints(int pixels, double dpi) {

--- a/src/main/java/com/example/asposetopdf/converters/JpegConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/JpegConverter.java
@@ -1,10 +1,8 @@
 package com.example.asposetopdf.converters;
 
-import com.aspose.pdf.Page;
+import com.aspose.pdf.ImageFilterType;
 
 import com.example.asposetopdf.detect.FileType;
-
-import java.nio.file.Path;
 
 /**
  * Converter for JPEG images.
@@ -15,7 +13,7 @@ public class JpegConverter extends ImageConverter {
     }
 
     @Override
-    protected void embedImage(Page page, Path input, double widthPoints, double heightPoints) {
-        embedNativeImage(page, input, widthPoints, heightPoints);
+    protected int getDefaultImageFilter() {
+        return ImageFilterType.Jpeg;
     }
 }

--- a/src/main/java/com/example/asposetopdf/converters/JpegConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/JpegConverter.java
@@ -1,0 +1,12 @@
+package com.example.asposetopdf.converters;
+
+import com.example.asposetopdf.detect.FileType;
+
+/**
+ * Converter for JPEG images.
+ */
+public class JpegConverter extends ImageConverter {
+    public JpegConverter() {
+        super(FileType.JPEG);
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/JpegConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/JpegConverter.java
@@ -1,6 +1,10 @@
 package com.example.asposetopdf.converters;
 
+import com.aspose.pdf.Page;
+
 import com.example.asposetopdf.detect.FileType;
+
+import java.nio.file.Path;
 
 /**
  * Converter for JPEG images.
@@ -8,5 +12,10 @@ import com.example.asposetopdf.detect.FileType;
 public class JpegConverter extends ImageConverter {
     public JpegConverter() {
         super(FileType.JPEG);
+    }
+
+    @Override
+    protected void embedImage(Page page, Path input, double widthPoints, double heightPoints) {
+        embedNativeImage(page, input, widthPoints, heightPoints);
     }
 }

--- a/src/main/java/com/example/asposetopdf/converters/MsgConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/MsgConverter.java
@@ -4,10 +4,8 @@ import com.aspose.email.MailConversionOptions;
 import com.aspose.email.MailMessage;
 import com.aspose.email.MapiMessage;
 import com.aspose.email.SaveOptions;
-import com.aspose.words.Document;
-import com.aspose.words.LoadFormat;
-import com.aspose.words.LoadOptions;
-import com.aspose.words.SaveFormat;
+import com.aspose.html.converters.Converter;
+import com.aspose.html.saving.PdfSaveOptions;
 import com.example.asposetopdf.detect.FileType;
 
 import java.io.ByteArrayInputStream;
@@ -26,13 +24,15 @@ public class MsgConverter extends BaseConverter {
     @Override
     public void convert(Path input, Path output) throws Exception {
         ensureParentDirectory(output);
-        MapiMessage mapiMessage = MapiMessage.load(input.toString());
-        MailMessage mailMessage = mapiMessage.toMailMessage(new MailConversionOptions());
-        try (ByteArrayOutputStream mhtmlStream = new ByteArrayOutputStream()) {
+        try (MapiMessage mapiMessage = MapiMessage.load(input.toString());
+             MailMessage mailMessage = mapiMessage.toMailMessage(new MailConversionOptions());
+             ByteArrayOutputStream mhtmlStream = new ByteArrayOutputStream()) {
             mailMessage.save(mhtmlStream, SaveOptions.getDefaultMhtml());
-            Document document = new Document(new ByteArrayInputStream(mhtmlStream.toByteArray()),
-                new LoadOptions(LoadFormat.MHTML));
-            document.save(output.toString(), SaveFormat.PDF);
+            byte[] mhtmlBytes = mhtmlStream.toByteArray();
+            try (ByteArrayInputStream mhtmlInput = new ByteArrayInputStream(mhtmlBytes)) {
+                Converter.convertMHTML(mhtmlInput, new PdfSaveOptions(), output.toString());
+            }
         }
     }
 }
+

--- a/src/main/java/com/example/asposetopdf/converters/MsgConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/MsgConverter.java
@@ -1,0 +1,38 @@
+package com.example.asposetopdf.converters;
+
+import com.aspose.email.MailConversionOptions;
+import com.aspose.email.MailMessage;
+import com.aspose.email.MapiMessage;
+import com.aspose.email.SaveOptions;
+import com.aspose.words.Document;
+import com.aspose.words.LoadFormat;
+import com.aspose.words.LoadOptions;
+import com.aspose.words.SaveFormat;
+import com.example.asposetopdf.detect.FileType;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Path;
+
+/**
+ * Converter for Outlook MSG files.
+ */
+public class MsgConverter extends BaseConverter {
+    @Override
+    public FileType getFileType() {
+        return FileType.MSG;
+    }
+
+    @Override
+    public void convert(Path input, Path output) throws Exception {
+        ensureParentDirectory(output);
+        MapiMessage mapiMessage = MapiMessage.load(input.toString());
+        MailMessage mailMessage = mapiMessage.toMailMessage(new MailConversionOptions());
+        try (ByteArrayOutputStream mhtmlStream = new ByteArrayOutputStream()) {
+            mailMessage.save(mhtmlStream, SaveOptions.getDefaultMhtml());
+            Document document = new Document(new ByteArrayInputStream(mhtmlStream.toByteArray()),
+                new LoadOptions(LoadFormat.MHTML));
+            document.save(output.toString(), SaveFormat.PDF);
+        }
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/PdfConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/PdfConverter.java
@@ -1,0 +1,27 @@
+package com.example.asposetopdf.converters;
+
+import com.aspose.pdf.Document;
+import com.example.asposetopdf.detect.FileType;
+
+import java.nio.file.Path;
+
+/**
+ * Converter for PDF inputs. Re-saves the document to ensure consistency.
+ */
+public class PdfConverter extends BaseConverter {
+    @Override
+    public FileType getFileType() {
+        return FileType.PDF;
+    }
+
+    @Override
+    public void convert(Path input, Path output) throws Exception {
+        ensureParentDirectory(output);
+        Document document = new Document(input.toString());
+        try {
+            document.save(output.toString());
+        } finally {
+            document.close();
+        }
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/PngConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/PngConverter.java
@@ -1,10 +1,6 @@
 package com.example.asposetopdf.converters;
 
-import com.aspose.pdf.Page;
-
 import com.example.asposetopdf.detect.FileType;
-
-import java.nio.file.Path;
 
 /**
  * Converter for PNG images.
@@ -12,10 +8,5 @@ import java.nio.file.Path;
 public class PngConverter extends ImageConverter {
     public PngConverter() {
         super(FileType.PNG);
-    }
-
-    @Override
-    protected void embedImage(Page page, Path input, double widthPoints, double heightPoints) {
-        embedNativeImage(page, input, widthPoints, heightPoints);
     }
 }

--- a/src/main/java/com/example/asposetopdf/converters/PngConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/PngConverter.java
@@ -1,0 +1,12 @@
+package com.example.asposetopdf.converters;
+
+import com.example.asposetopdf.detect.FileType;
+
+/**
+ * Converter for PNG images.
+ */
+public class PngConverter extends ImageConverter {
+    public PngConverter() {
+        super(FileType.PNG);
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/PngConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/PngConverter.java
@@ -1,6 +1,10 @@
 package com.example.asposetopdf.converters;
 
+import com.aspose.pdf.Page;
+
 import com.example.asposetopdf.detect.FileType;
+
+import java.nio.file.Path;
 
 /**
  * Converter for PNG images.
@@ -8,5 +12,10 @@ import com.example.asposetopdf.detect.FileType;
 public class PngConverter extends ImageConverter {
     public PngConverter() {
         super(FileType.PNG);
+    }
+
+    @Override
+    protected void embedImage(Page page, Path input, double widthPoints, double heightPoints) {
+        embedNativeImage(page, input, widthPoints, heightPoints);
     }
 }

--- a/src/main/java/com/example/asposetopdf/converters/PptxConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/PptxConverter.java
@@ -1,0 +1,28 @@
+package com.example.asposetopdf.converters;
+
+import com.aspose.slides.Presentation;
+import com.aspose.slides.SaveFormat;
+import com.example.asposetopdf.detect.FileType;
+
+import java.nio.file.Path;
+
+/**
+ * Converter for PPTX presentations.
+ */
+public class PptxConverter extends BaseConverter {
+    @Override
+    public FileType getFileType() {
+        return FileType.PPTX;
+    }
+
+    @Override
+    public void convert(Path input, Path output) throws Exception {
+        ensureParentDirectory(output);
+        Presentation presentation = new Presentation(input.toString());
+        try {
+            presentation.save(output.toString(), SaveFormat.Pdf);
+        } finally {
+            presentation.dispose();
+        }
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/TiffConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/TiffConverter.java
@@ -1,0 +1,71 @@
+package com.example.asposetopdf.converters;
+
+import com.aspose.imaging.Image;
+import com.aspose.imaging.fileformats.png.PngColorType;
+import com.aspose.imaging.fileformats.tiff.TiffFrame;
+import com.aspose.imaging.fileformats.tiff.TiffImage;
+import com.aspose.imaging.imageoptions.PngOptions;
+import com.aspose.pdf.Document;
+import com.aspose.pdf.MarginInfo;
+import com.aspose.pdf.Page;
+import com.example.asposetopdf.detect.FileType;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Path;
+
+/**
+ * Converter for TIFF images.
+ */
+public class TiffConverter extends ImageConverter {
+    public TiffConverter() {
+        super(FileType.TIFF);
+    }
+
+    @Override
+    public void convert(Path input, Path output) throws Exception {
+        ensureParentDirectory(output);
+
+        try (Image image = Image.load(input.toString())) {
+            if (!(image instanceof TiffImage)) {
+                super.convert(input, output);
+                return;
+            }
+
+            TiffImage tiff = (TiffImage) image;
+            Document document = new Document();
+            try {
+                MarginInfo margin = new MarginInfo(0, 0, 0, 0);
+                document.getPageInfo().setMargin(margin);
+
+                for (TiffFrame frame : tiff.getFrames()) {
+                    Page page = document.getPages().add();
+                    page.getPageInfo().setMargin(margin);
+                    setPageDimensions(page, frame.getWidth(), frame.getHeight(),
+                            frame.getHorizontalResolution(), frame.getVerticalResolution());
+
+                    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                        PngOptions options = new PngOptions();
+                        options.setCompressionLevel(0);
+                        if (frame.getBitsPerPixel() == 1) {
+                            options.setColorType(PngColorType.Grayscale);
+                            options.setBitDepth((byte) 1);
+                        }
+                        frame.save(baos, options);
+
+                        com.aspose.pdf.Image pdfImage = new com.aspose.pdf.Image();
+                        pdfImage.setImageStream(new ByteArrayInputStream(baos.toByteArray()));
+                        pdfImage.setFixWidth(page.getPageInfo().getWidth());
+                        pdfImage.setFixHeight(page.getPageInfo().getHeight());
+                        pdfImage.setIsApplyResolution(true);
+                        page.getParagraphs().add(pdfImage);
+                    }
+                }
+
+                document.save(output.toString());
+            } finally {
+                document.close();
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/TiffConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/TiffConverter.java
@@ -1,16 +1,18 @@
 package com.example.asposetopdf.converters;
 
 import com.aspose.imaging.Image;
-import com.aspose.imaging.fileformats.png.PngColorType;
+import com.aspose.imaging.ResolutionSetting;
 import com.aspose.imaging.fileformats.tiff.TiffFrame;
 import com.aspose.imaging.fileformats.tiff.TiffImage;
+import com.aspose.imaging.fileformats.tiff.enums.TiffExpectedFormat;
 import com.aspose.imaging.imageoptions.PngOptions;
+import com.aspose.imaging.imageoptions.TiffOptions;
 import com.aspose.pdf.Document;
+import com.aspose.pdf.ImageFilterType;
 import com.aspose.pdf.MarginInfo;
 import com.aspose.pdf.Page;
 import com.example.asposetopdf.detect.FileType;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Path;
 
@@ -44,21 +46,24 @@ public class TiffConverter extends ImageConverter {
                     setPageDimensions(page, frame.getWidth(), frame.getHeight(),
                             frame.getHorizontalResolution(), frame.getVerticalResolution());
 
+                    double widthPoints = page.getPageInfo().getWidth();
+                    double heightPoints = page.getPageInfo().getHeight();
+
+                    if (frame.getBitsPerPixel() == 1) {
+                        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                             TiffOptions tiffOptions = new TiffOptions(TiffExpectedFormat.TiffCcittFax4)) {
+                            tiffOptions.setResolutionSettings(new ResolutionSetting(frame.getHorizontalResolution(), frame.getVerticalResolution()));
+                            frame.save(baos, tiffOptions);
+                            embedImage(page, baos.toByteArray(), widthPoints, heightPoints, ImageFilterType.CCITTFax);
+                        }
+                        continue;
+                    }
+
                     try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
                         PngOptions options = new PngOptions();
                         options.setCompressionLevel(0);
-                        if (frame.getBitsPerPixel() == 1) {
-                            options.setColorType(PngColorType.Grayscale);
-                            options.setBitDepth((byte) 1);
-                        }
                         frame.save(baos, options);
-
-                        com.aspose.pdf.Image pdfImage = new com.aspose.pdf.Image();
-                        pdfImage.setImageStream(new ByteArrayInputStream(baos.toByteArray()));
-                        pdfImage.setFixWidth(page.getPageInfo().getWidth());
-                        pdfImage.setFixHeight(page.getPageInfo().getHeight());
-                        pdfImage.setIsApplyResolution(true);
-                        page.getParagraphs().add(pdfImage);
+                        embedImage(page, baos.toByteArray(), widthPoints, heightPoints);
                     }
                 }
 
@@ -68,4 +73,5 @@ public class TiffConverter extends ImageConverter {
             }
         }
     }
+
 }

--- a/src/main/java/com/example/asposetopdf/converters/VisioConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/VisioConverter.java
@@ -22,7 +22,8 @@ public class VisioConverter extends BaseConverter {
         try {
             diagram.save(output.toString(), SaveFileFormat.PDF);
         } finally {
-            diagram.close();
+            diagram.dispose();
         }
     }
 }
+

--- a/src/main/java/com/example/asposetopdf/converters/VisioConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/VisioConverter.java
@@ -1,0 +1,28 @@
+package com.example.asposetopdf.converters;
+
+import com.aspose.diagram.Diagram;
+import com.aspose.diagram.SaveFileFormat;
+import com.example.asposetopdf.detect.FileType;
+
+import java.nio.file.Path;
+
+/**
+ * Converter for Visio drawings.
+ */
+public class VisioConverter extends BaseConverter {
+    @Override
+    public FileType getFileType() {
+        return FileType.VISIO;
+    }
+
+    @Override
+    public void convert(Path input, Path output) throws Exception {
+        ensureParentDirectory(output);
+        Diagram diagram = new Diagram(input.toString());
+        try {
+            diagram.save(output.toString(), SaveFileFormat.PDF);
+        } finally {
+            diagram.close();
+        }
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/XlsxConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/XlsxConverter.java
@@ -1,0 +1,24 @@
+package com.example.asposetopdf.converters;
+
+import com.aspose.cells.SaveFormat;
+import com.aspose.cells.Workbook;
+import com.example.asposetopdf.detect.FileType;
+
+import java.nio.file.Path;
+
+/**
+ * Converter for XLSX spreadsheets.
+ */
+public class XlsxConverter extends BaseConverter {
+    @Override
+    public FileType getFileType() {
+        return FileType.XLSX;
+    }
+
+    @Override
+    public void convert(Path input, Path output) throws Exception {
+        ensureParentDirectory(output);
+        Workbook workbook = new Workbook(input.toString());
+        workbook.save(output.toString(), SaveFormat.PDF);
+    }
+}

--- a/src/main/java/com/example/asposetopdf/converters/XlsxConverter.java
+++ b/src/main/java/com/example/asposetopdf/converters/XlsxConverter.java
@@ -1,15 +1,19 @@
 package com.example.asposetopdf.converters;
 
-import com.aspose.cells.SaveFormat;
-import com.aspose.cells.Workbook;
+import com.aspose.cells.*;
 import com.example.asposetopdf.detect.FileType;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Locale;
+import java.text.DecimalFormatSymbols;
 
 /**
  * Converter for XLSX spreadsheets.
  */
 public class XlsxConverter extends BaseConverter {
+    static double CELL_PADDING = 0.1;
+
     @Override
     public FileType getFileType() {
         return FileType.XLSX;
@@ -19,6 +23,137 @@ public class XlsxConverter extends BaseConverter {
     public void convert(Path input, Path output) throws Exception {
         ensureParentDirectory(output);
         Workbook workbook = new Workbook(input.toString());
-        workbook.save(output.toString(), SaveFormat.PDF);
+        workbook.getSettings().setLocale(Locale.US);
+        workbook.getSettings().setNumberDecimalSeparator('.');
+        workbook.getSettings().setNumberGroupSeparator(',');
+        workbook.calculateFormula();
+        PdfSaveOptions pdfOptions = new PdfSaveOptions();
+        pdfOptions.setGridlineType(GridlineType.HAIR);
+        pdfOptions.setGridlineColor(Color.getLightGray());
+        pdfOptions.setExportDocumentStructure(true);
+        pdfOptions.setDisplayDocTitle(true);
+        modifyPageSetup(workbook);
+        sanitizeCharts(workbook);
+        addWorksheetBookmarks(workbook, pdfOptions);
+        workbook.save(output.toString(), pdfOptions);
+    }
+
+    private void addWorksheetBookmarks(Workbook workbook, PdfSaveOptions options) {
+        PdfBookmarkEntry root = new PdfBookmarkEntry();
+        root.setText("Worksheets");
+
+        ArrayList<PdfBookmarkEntry> entries = new ArrayList<>();
+        for (int i = 0; i < workbook.getWorksheets().getCount(); i++) {
+            Worksheet sheet = workbook.getWorksheets().get(i);
+            Range displayRange = sheet.getCells().getMaxDisplayRange();
+            if (displayRange == null || displayRange.getRowCount() == 0 || displayRange.getColumnCount() == 0) {
+                continue;
+            }
+
+            PdfBookmarkEntry entry = new PdfBookmarkEntry();
+            entry.setText(sheet.getName());
+            entry.setDestination(sheet.getCells().get(displayRange.getFirstRow(), displayRange.getFirstColumn()));
+            entries.add(entry);
+        }
+
+        if (entries.isEmpty()) {
+            return;
+        }
+
+        root.setDestination(entries.get(0).getDestination());
+        root.setSubEntry(entries);
+        options.setBookmark(root);
+    }
+
+
+    private void sanitizeCharts(Workbook workbook) {
+        for (Worksheet sheet : workbook.getWorksheets()) {
+            for (Chart chart : sheet.getCharts()) {
+                if (chart.getType() == ChartType.LINE_WITH_DATA_MARKERS && chart.getValueAxis() != null) {
+                    chart.getValueAxis().setNumberFormatLinked(false);
+                    chart.getValueAxis().setNumberFormat("0.00E+00");
+                }
+            }
+        }
+    }
+
+    private void modifyPageSetup(Workbook workbook) {
+        for (int i = 0; i < workbook.getWorksheets().getCount(); i++) {
+            Worksheet ws = workbook.getWorksheets().get(i);
+            Cells cells = ws.getCells();
+            Range used = cells.getMaxDisplayRange();
+            if (used == null || used.getRowCount() == 0 || used.getColumnCount() == 0) {
+                System.out.printf("Worksheet '%s' has no visible cells; skipping.\n", ws.getName());
+                continue;
+            }
+            int fc = used.getFirstColumn();
+            int lc = fc + used.getColumnCount() - 1;
+            int fr = used.getFirstRow();
+            int lr = fr + used.getRowCount() - 1;
+            System.out.printf("Worksheet '%s' has this displayRange Cols: %d-%d, Rows: %d-%d\n", ws.getName(), fc, lc, fr, lr);
+
+            PageSetup pageSetup = ws.getPageSetup();
+            
+            // Disable "fit to page" scaling; keep 100% zoom
+            pageSetup.setPercentScale(true);
+            pageSetup.setZoom(100);
+            pageSetup.setFitToPagesWide(0);
+            pageSetup.setFitToPagesTall(0);
+
+            // Remove old page breaks
+            ws.getHorizontalPageBreaks().clear();
+            ws.getVerticalPageBreaks().clear();
+
+            // Change margins
+            pageSetup.setLeftMarginInch(0.15);
+            pageSetup.setRightMarginInch(0.15);
+            pageSetup.setTopMarginInch(0.15);
+            pageSetup.setBottomMarginInch(0.15);
+            pageSetup.setHeaderMarginInch(0.1);
+            pageSetup.setFooterMarginInch(0.1);
+
+            // Add grid lines
+            pageSetup.setPrintGridlines(true);
+            pageSetup.setCenterHorizontally(true);
+            pageSetup.setCenterVertically(true);
+
+            // Set what to print, for predictable results
+            pageSetup.setPrintArea(
+                CellsHelper.cellIndexToName(fr, fc) + ":" +
+                CellsHelper.cellIndexToName(lr, lc)
+            );
+
+            // Sum width/height of the used range in **inches**
+            double widthIn = 0.0;
+            for (int c = fc; c <= lc; c++) {
+                widthIn += cells.getColumnWidth(c, true, CellsUnitType.INCH) + CELL_PADDING;
+            }
+
+            double heightIn = 0.0;
+            for (int r = fr; r <= lr; r++) {
+                heightIn += cells.getRowHeight(r, /*isOriginal*/true, CellsUnitType.INCH);
+            }
+
+            // Add margins, header/footer space, and set a custom paper size (units are inches)
+            double leftMargin = pageSetup.getLeftMarginInch();
+            double rightMargin = pageSetup.getRightMarginInch();
+            double topMargin = pageSetup.getTopMarginInch();
+            double bottomMargin = pageSetup.getBottomMarginInch();
+            double headerMargin = pageSetup.getHeaderMarginInch();
+            double footerMargin = pageSetup.getFooterMarginInch();
+
+            double w = widthIn + leftMargin + rightMargin;
+            double h = heightIn + topMargin + bottomMargin + headerMargin + footerMargin;
+
+            double widthPadding = 0.25;
+            double heightPadding = 0.15;
+            w += widthPadding;
+            h += heightPadding;
+
+            pageSetup.setHeader(1, String.format("&C&\"Arial,Bold\"&12%s", ws.getName()));
+            System.out.printf("Setting paper size to %.2fx%.2f inches%n", w, h);
+            pageSetup.customPaperSize(w, h);  // this is the key
+        }
+
     }
 }

--- a/src/main/java/com/example/asposetopdf/detect/FileType.java
+++ b/src/main/java/com/example/asposetopdf/detect/FileType.java
@@ -1,0 +1,48 @@
+package com.example.asposetopdf.detect;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Supported input file types.
+ */
+public enum FileType {
+    PDF("pdf"),
+    JPEG("jpg"),
+    DOCX("docx"),
+    EML("eml"),
+    PNG("png"),
+    MSG("msg"),
+    XLSX("xlsx"),
+    TIFF("tif"),
+    VISIO("visio"),
+    PPTX("pptx"),
+    DWG("dwg");
+
+    private final String defaultExtension;
+
+    FileType(String defaultExtension) {
+        this.defaultExtension = defaultExtension;
+    }
+
+    public String getDefaultExtension() {
+        return defaultExtension;
+    }
+
+    public static Optional<FileType> fromExtension(String extension) {
+        if (extension == null || extension.isBlank()) {
+            return Optional.empty();
+        }
+        String normalized = extension.toLowerCase(Locale.ROOT);
+        for (FileType type : values()) {
+            if (type.defaultExtension.equals(normalized) ||
+                (type == JPEG && normalized.equals("jpeg")) ||
+                (type == TIFF && (normalized.equals("tiff"))) ||
+                (type == VISIO && (normalized.equals("vsdx") || normalized.equals("vsd"))) ||
+                (type == DWG && normalized.equals("dwg"))) {
+                return Optional.of(type);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/example/asposetopdf/detect/FileTypeDetector.java
+++ b/src/main/java/com/example/asposetopdf/detect/FileTypeDetector.java
@@ -1,0 +1,164 @@
+package com.example.asposetopdf.detect;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/**
+ * Detects the {@link FileType} for an input file using magic bytes and structural checks.
+ */
+public final class FileTypeDetector {
+    private static final byte[] PDF_MAGIC = "%PDF".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] JPEG_MAGIC = new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF};
+    private static final byte[] PNG_MAGIC = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+    private static final byte[] TIFF_MAGIC_LE = new byte[]{0x49, 0x49, 0x2A, 0x00};
+    private static final byte[] TIFF_MAGIC_BE = new byte[]{0x4D, 0x4D, 0x00, 0x2A};
+    private static final byte[] MSG_MAGIC = new byte[]{(byte) 0xD0, (byte) 0xCF, 0x11, (byte) 0xE0, (byte) 0xA1, (byte) 0xB1, 0x1A, (byte) 0xE1};
+    private static final byte[] DWG_MAGIC_PREFIX = "AC10".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] ZIP_MAGIC = new byte[]{0x50, 0x4B, 0x03, 0x04};
+
+    private FileTypeDetector() {
+    }
+
+    public static FileType detect(Path input) throws IOException {
+        byte[] header = readHeader(input, 512);
+
+        if (startsWith(header, PDF_MAGIC)) {
+            return FileType.PDF;
+        }
+        if (startsWith(header, JPEG_MAGIC)) {
+            return FileType.JPEG;
+        }
+        if (startsWith(header, PNG_MAGIC)) {
+            return FileType.PNG;
+        }
+        if (startsWith(header, TIFF_MAGIC_LE) || startsWith(header, TIFF_MAGIC_BE)) {
+            return FileType.TIFF;
+        }
+        if (startsWith(header, MSG_MAGIC)) {
+            return FileType.MSG;
+        }
+        if (startsWith(header, DWG_MAGIC_PREFIX)) {
+            return FileType.DWG;
+        }
+        if (startsWith(header, ZIP_MAGIC)) {
+            FileType zippedType = detectZipBasedType(input);
+            if (zippedType != null) {
+                return zippedType;
+            }
+        }
+
+        if (looksLikeEmail(header)) {
+            return FileType.EML;
+        }
+
+        Optional<FileType> fallback = FileType.fromExtension(getExtension(input));
+        return fallback.orElseThrow(() ->
+            new UnsupportedOperationException("Unsupported file type for input: " + input));
+    }
+
+    private static boolean startsWith(byte[] data, byte[] prefix) {
+        if (data.length < prefix.length) {
+            return false;
+        }
+        for (int i = 0; i < prefix.length; i++) {
+            if (data[i] != prefix[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static byte[] readHeader(Path input, int length) throws IOException {
+        byte[] buffer = new byte[length];
+        int read;
+        try (InputStream stream = Files.newInputStream(input)) {
+            read = stream.read(buffer);
+        }
+        if (read == -1) {
+            return new byte[0];
+        }
+        return Arrays.copyOf(buffer, read);
+    }
+
+    private static String getExtension(Path input) {
+        String name = input.getFileName().toString();
+        int dot = name.lastIndexOf('.');
+        if (dot == -1) {
+            return "";
+        }
+        return name.substring(dot + 1).toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean looksLikeEmail(byte[] header) {
+        String snippet = new String(header, StandardCharsets.US_ASCII).toLowerCase(Locale.ROOT);
+        return snippet.contains("mime-version:") || snippet.contains("content-type:")
+            || snippet.startsWith("from ") || snippet.contains("return-path:");
+    }
+
+    private static FileType detectZipBasedType(Path input) throws IOException {
+        try (ZipFile zipFile = new ZipFile(input.toFile())) {
+            boolean hasWord = false;
+            boolean hasExcel = false;
+            boolean hasPowerPoint = false;
+            boolean hasVisio = false;
+
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                String name = entry.getName();
+                if (name.startsWith("word/")) {
+                    hasWord = true;
+                }
+                if (name.startsWith("xl/")) {
+                    hasExcel = true;
+                }
+                if (name.startsWith("ppt/")) {
+                    hasPowerPoint = true;
+                }
+                if (name.startsWith("visio/")) {
+                    hasVisio = true;
+                }
+                if ("[Content_Types].xml".equals(name)) {
+                    try (InputStream in = zipFile.getInputStream(entry)) {
+                        String content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+                        if (content.contains("wordprocessingml.document")) {
+                            hasWord = true;
+                        }
+                        if (content.contains("spreadsheetml.sheet")) {
+                            hasExcel = true;
+                        }
+                        if (content.contains("presentationml.presentation")) {
+                            hasPowerPoint = true;
+                        }
+                        if (content.contains("visio.document")) {
+                            hasVisio = true;
+                        }
+                    }
+                }
+            }
+
+            if (hasWord) {
+                return FileType.DOCX;
+            }
+            if (hasExcel) {
+                return FileType.XLSX;
+            }
+            if (hasPowerPoint) {
+                return FileType.PPTX;
+            }
+            if (hasVisio) {
+                return FileType.VISIO;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- enhance the DWG converter to autodetect available layouts and fall back to Model when none are discovered
- rely on reflective lookups so the layout probing works across multiple Aspose CAD releases while keeping output sizing logic intact
- document the refined DWG handling in the supported formats list

## Testing
- `mvn -DskipTests package` *(fails: Aspose repository returns 403 Forbidden without credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68da8f0b38f0832d92f979a122119116